### PR TITLE
Added new dbt model to track unique public IPs

### DIFF
--- a/dbt/spotify_dbt/models/gold/_gold_models.yml
+++ b/dbt/spotify_dbt/models/gold/_gold_models.yml
@@ -14,3 +14,11 @@ models:
         description: Number of API calls for given aggregation
       - name: avg_response_time
         description: Average response time for given aggregation
+  - name: gold_unique_ips
+    description: '{{ doc("gold_unique_ips") }}'
+    config:
+      tags: transformed
+    columns:
+      - name: ip_address
+      - name: first_seen_ts
+        description: When the public IP made its first request to the server

--- a/dbt/spotify_dbt/models/gold/docs/gold_unique_ips.md
+++ b/dbt/spotify_dbt/models/gold/docs/gold_unique_ips.md
@@ -1,0 +1,6 @@
+{% docs gold_unique_ips %}
+
+Aggregates all unique public IPs found in `dbt_silver.silver_api_logs`, and 
+returns the earliest timestamp found.
+
+{% enddocs %}

--- a/dbt/spotify_dbt/models/gold/gold_unique_ips.sql
+++ b/dbt/spotify_dbt/models/gold/gold_unique_ips.sql
@@ -1,0 +1,11 @@
+select
+   ip_address,
+   min(timestamp) as first_seen_ts
+from
+   {{ ref('silver_api_logs') }}
+where
+    ip_address is not null
+group by
+   ip_address
+order by
+   first_seen_ts desc


### PR DESCRIPTION
I've added a new gold layer dbt model to track unique public IPs, along with when they were first seen. This will allow us to have a better understanding of our user base, by determining how many new users we're acquiring every month.